### PR TITLE
Add redirect for modding docs

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2,5 +2,6 @@
     "github": "https://github.com/R2Northstar",
     "discord": "https://discord.gg/northstar",
     "wiki": "https://r2northstar.gitbook.io/",
+    "moddingdocs": "https://r2northstar.readthedocs.io/",
     "thunderstore": "https://northstar.thunderstore.io"
 }


### PR DESCRIPTION
ModdingDocs are referenced in top bar but redirect gives 404