### PR TITLE
Change order of installers to FlightCore, VTOL, Viper, Manual on Northstar.tf

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -86,6 +86,11 @@
                     Fast and easy to use Northstar installer, updater, launcher, and mod-manager. Features built-in mod browser and allows for easy installation of pre-release versions of Northstar.
                     </p>Supports Windows and Linux.
                 </div>
+                <div class="buttons">
+                    <a ondragstart="return false;" href="https://r2northstartools.github.io/FlightCore/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
+                    <a ondragstart="return false;" href="https://github.com/R2NorthstarTools/FlightCore/" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
+                </div>
+            </div>
             <div class="launcher">
                 <div class="header"> 
                     <img src="/assets/vtol.png">
@@ -112,11 +117,6 @@
                 <div class="buttons">
                     <a ondragstart="return false;" href="https://0negal.github.io/viper/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
                     <a ondragstart="return false;" href="https://github.com/0neGal/viper" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
-                </div>
-            </div>
-                <div class="buttons">
-                    <a ondragstart="return false;" href="https://r2northstartools.github.io/FlightCore/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
-                    <a ondragstart="return false;" href="https://github.com/R2NorthstarTools/FlightCore/" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
                 </div>
             </div>
             <div class="launcher">

--- a/dist/index.html
+++ b/dist/index.html
@@ -79,18 +79,13 @@
         <div class="installoptions">
             <div class="launcher">
                 <div class="header"> 
-                    <img src="/assets/viper.png">
-                    <div class="name header">viper</div>
+                    <img src="/assets/flightcore.png">
+                    <div class="name header">flightcore</div>
                 </div>
                 <div class="blurb">
-                    Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.
+                    Fast and easy to use Northstar installer, updater, launcher, and mod-manager. Features built-in mod browser and allows for easy installation of pre-release versions of Northstar.
                     </p>Supports Windows and Linux.
                 </div>
-                <div class="buttons">
-                    <a ondragstart="return false;" href="https://0negal.github.io/viper/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
-                    <a ondragstart="return false;" href="https://github.com/0neGal/viper" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
-                </div>
-            </div>
             <div class="launcher">
                 <div class="header"> 
                     <img src="/assets/vtol.png">
@@ -107,13 +102,18 @@
             </div>
             <div class="launcher">
                 <div class="header"> 
-                    <img src="/assets/flightcore.png">
-                    <div class="name header">flightcore</div>
+                    <img src="/assets/viper.png">
+                    <div class="name header">viper</div>
                 </div>
                 <div class="blurb">
-                    Fast and easy to use Northstar installer, updater, launcher, and mod-manager. Features built-in mod browser and allows for easy installation of pre-release versions of Northstar.
+                    Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.
                     </p>Supports Windows and Linux.
                 </div>
+                <div class="buttons">
+                    <a ondragstart="return false;" href="https://0negal.github.io/viper/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
+                    <a ondragstart="return false;" href="https://github.com/0neGal/viper" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
+                </div>
+            </div>
                 <div class="buttons">
                     <a ondragstart="return false;" href="https://r2northstartools.github.io/FlightCore/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
                     <a ondragstart="return false;" href="https://github.com/R2NorthstarTools/FlightCore/" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>


### PR DESCRIPTION
FlightCore generally works better for end users, as well as being actively updated and maintained. Viper is still a good mod manager, and I think it should stay as an option (unless somehow we come to a conclusion and one centralized launcher)

I don't mean to cause any controversy or ill will towards 0negal with this change, and hope that it won't happen