### PR TITLE
Update VTOL link to use newest installer link

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -101,7 +101,7 @@
                     </p>Supports Windows.
                 </div>
                 <div class="buttons">
-                    <a ondragstart="return false;" href="https://drive.google.com/file/d/1V2hpKkeGmqUGVol6S3sZK76p1NlaWwX1/view" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
+                    <a ondragstart="return false;" href="https://github.com/BigSpice/VTOL/releases/latest/download/VTOL_Installer.msi" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
                     <a ondragstart="return false;" href="https://github.com/BigSpice/VTOL" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
                 </div>
             </div>


### PR DESCRIPTION
Most users installing VTOL choose to use the northstar.tf download (which is a portable version) and as such don't automatically receive updates