### PR TITLE
Change `Installation` to `Launchers`, add clarification subtext

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -75,7 +75,7 @@
         </div>
     </div>
     <div class="pane" id="main">
-        <div class="section">Installation</div>
+        <div class="section">Installing Northstar</div>
         <div class="installoptions">
             <div class="launcher">
                 <div class="header"> 

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,7 +75,8 @@
         </div>
     </div>
     <div class="pane" id="main">
-        <div class="section">Northstar installation methods</div>
+        <div class="section">Launchers</div>
+        <p style="text-align: center" class="launchersubtext">Note: These all run the same Northstar! They're just different ways to install Northstar and mods for it, with all but Manual being automatic</p>
         <div class="installoptions">
             <div class="launcher">
                 <div class="header"> 

--- a/dist/index.html
+++ b/dist/index.html
@@ -75,7 +75,7 @@
         </div>
     </div>
     <div class="pane" id="main">
-        <div class="section">Installing Northstar</div>
+        <div class="section">Northstar installation methods</div>
         <div class="installoptions">
             <div class="launcher">
                 <div class="header"> 


### PR DESCRIPTION
Pretty sure I changed the right line, hopefully I did

A lot of new users tend to get confused and think all 4 "main" ways to install Northstar are different clients with different servers, so hopefully clarifying that it's _different ways to install the same Northstar_ can cut down on at least a couple cases where people ask about it in the discord

Completely open to suggestions, edits, or thoughts 