### PR TITLE
Remove search query on Viper's download link

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -110,7 +110,7 @@
                     </p>Supports Windows and Linux.
                 </div>
                 <div class="buttons">
-                    <a ondragstart="return false;" href="https://0negal.github.io/viper/index.html?win-setup" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
+                    <a ondragstart="return false;" href="https://0negal.github.io/viper" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
                     <a ondragstart="return false;" href="https://github.com/0neGal/viper" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
                 </div>
             </div>


### PR DESCRIPTION
Without the search query, you'll be prompted with the Viper website which just lets you click download manually, or click for more download options.

Aka it just changes the download link from this: [`https://0negal.github.io/viper/index.html?win-setup`](https://0negal.github.io/viper/index.html?win-setup)
To this: [`https://0negal.github.io/viper`](https://0negal.github.io/viper)