### PR TITLE
Link to Mastodon profile for verification

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -30,6 +30,9 @@
     <meta property="twitter:title" content="Northstar">
     <meta property="twitter:description" content="Northstar is a modding framework client that allows users to host their own Titanfall 2 servers using custom scripts and assets to create custom content, as well as being able to host vanilla content.">
     <meta property="twitter:image" content="/assets/NorthstarPromoPosterOG.jpg">
+
+    <!-- Mastodon verification -->
+    <a rel="me" href="https://fosstodon.org/@R2Northstar">Mastodon</a>
 </head>
 <body>
     <div id="top">

--- a/dist/index.html
+++ b/dist/index.html
@@ -30,9 +30,6 @@
     <meta property="twitter:title" content="Northstar">
     <meta property="twitter:description" content="Northstar is a modding framework client that allows users to host their own Titanfall 2 servers using custom scripts and assets to create custom content, as well as being able to host vanilla content.">
     <meta property="twitter:image" content="/assets/NorthstarPromoPosterOG.jpg">
-
-    <!-- Mastodon verification -->
-    <a rel="me" href="https://fosstodon.org/@R2Northstar">Mastodon</a>
 </head>
 <body>
     <div id="top">
@@ -148,6 +145,8 @@
         <a ondragstart="return false;" href="/github"><img src="/assets/github.png" alt="Modding Documentation"/>GitHub</a>
         <a ondragstart="return false;" href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
         <a ondragstart="return false;" href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
+        <!-- Mastodon verification -->
+        <a rel="me" href="https://fosstodon.org/@R2Northstar" style="display: none; visibility: hidden;">Mastodon</a>
     </div>
     <script src="/script/index.js"></script>
 </body>


### PR DESCRIPTION
This is needed to verify the link to `northstar.tf` on the [Northstar Fosstodon account](https://fosstodon.org/@R2Northstar).

![image](https://github.com/R2Northstar/NorthstarTF/assets/40122905/56fee651-1ba5-4089-a266-41470553860b)

The tag is purposefully inside the head of the page as I don't know whether we want to (visually) link to the account from the website yet.

