### PR TITLE
Load credits from JSON files

### DIFF
--- a/dist/data/contrib.json
+++ b/dist/data/contrib.json
@@ -1,0 +1,158 @@
+[
+    {
+        "url": "https://github.com/BigSpice",
+        "icon": "https://avatars.githubusercontent.com/u/23240514?v=4",
+        "name": "juicy",
+        "description": "VTOL, Skins"
+    },
+    {
+        "url": "https://github.com/taskinoz",
+        "icon": "https://avatars.githubusercontent.com/u/7439692?v=4",
+        "name": "taskinoz",
+        "description": "Moderator, NavMeshes"
+    },
+    {
+        "url": "https://github.com/laundmo",
+        "icon": "https://avatars.githubusercontent.com/u/24855949?v=4",
+        "name": "laundmo",
+        "description": "Modding Docs, Chathooks"
+    },
+    {
+        "url": "https://github.com/DBmaoha/",
+        "icon": "https://avatars.githubusercontent.com/u/56738369?v=4",
+        "name": "VoyageDB",
+        "description": "Frontier War, Bounty Hunt, Squirrel bug fixes"
+    },
+    {
+        "url": "https://github.com/barnabwhy",
+        "icon": "https://avatars.githubusercontent.com/u/22575741?v=4",
+        "name": "barnaby",
+        "description": "Master Server, Website"
+    },
+    {
+        "url": "https://github.com/Erlite",
+        "icon": "https://avatars.githubusercontent.com/u/25248023?v=4",
+        "name": "erlite",
+        "description": "Spyglass, WebSquirrel, Security"
+    },
+    {
+        "url": "https://github.com/Mauler125",
+        "icon": "https://avatars.githubusercontent.com/u/48657826?v=4",
+        "name": "amos",
+        "description": "Source Genius, RCON, R5R, Security"
+    },
+    {
+        "url": "https://github.com/cpdt",
+        "icon": "https://avatars.githubusercontent.com/u/16081865?v=4",
+        "name": "snnag",
+        "description": "Chathooks, Server Browser, Exploit fixes, Security"
+    },
+    {
+        "url": "https://github.com/F1F7Y",
+        "icon": "https://avatars.githubusercontent.com/u/64418963?v=4",
+        "name": "f1f7y",
+        "description": "Server Browser, Attrition, Maps"
+    },
+    {
+        "url": "https://github.com/snake-biscuits",
+        "icon": "https://avatars.githubusercontent.com/u/36507175?v=4",
+        "name": "b1scuit",
+        "description": "Maps"
+    },
+    {
+        "url": "https://github.com/Legonzaur",
+        "icon": "https://avatars.githubusercontent.com/u/34353603?v=4",
+        "name": "legonzaur",
+        "description": "Discord Bot"
+    },
+    {
+        "url": "https://github.com/catornot",
+        "icon": "https://avatars.githubusercontent.com/u/41955154?v=4",
+        "name": "cat_or_not",
+        "description": "Co-Op Singleplayer"
+    },
+    {
+        "url": "https://github.com/x3Karma",
+        "icon": "https://avatars.githubusercontent.com/u/22678145?v=4",
+        "name": "x3karma",
+        "description": "Moderator, Modding, Frontier Defense"
+    },
+    {
+        "url": "https://github.com/Alystrasz",
+        "icon": "https://avatars.githubusercontent.com/u/11993538?v=4",
+        "name": "alystrasz",
+        "description": "Localisations, Launchers, Documentation"
+    },
+    {
+        "url": "https://github.com/Dinorush",
+        "icon": "https://avatars.githubusercontent.com/u/62536724?v=4",
+        "name": "dinorush",
+        "description": "Gamemodes"
+    },
+    {
+        "url": "https://github.com/hummusbird",
+        "icon": "https://avatars.githubusercontent.com/u/38541651?v=4",
+        "name": "birb",
+        "description": "Server Bot"
+    },
+    {
+        "url": "https://github.com/H0L0theBard",
+        "icon": "https://avatars.githubusercontent.com/u/97146561?v=4",
+        "name": "h0l0",
+        "description": "Moderator, Server Bot, Co-Op Singleplayer"
+    },
+    {
+        "url": "https://github.com/uniboi",
+        "icon": "https://avatars.githubusercontent.com/u/64006268?v=4",
+        "name": "uniboi",
+        "description": "Modding Docs"
+    },
+    {
+        "url": "https://github.com/EladNLG",
+        "icon": "https://avatars.githubusercontent.com/u/44613424?v=4",
+        "name": "eladnlg",
+        "description": "UI, Modding, Roguelike"
+    },
+    {
+        "url": "https://github.com/r-ex",
+        "icon": "https://avatars.githubusercontent.com/u/67599507?v=4",
+        "name": "rexx",
+        "description": "Custom Models, </br> Legion, RePak"
+    },
+    {
+        "url": "https://github.com/headassbtw",
+        "icon": "https://avatars.githubusercontent.com/u/16214950?v=4",
+        "name": "headass",
+        "description": "Custom Models"
+    },
+    {
+        "url": "https://github.com/Masterliberty",
+        "icon": "https://avatars.githubusercontent.com/u/94194459?v=4",
+        "name": "masterliberty",
+        "description": "Custom Models"
+    },
+    {
+        "url": "https://github.com/KyleGospo",
+        "icon": "https://avatars.githubusercontent.com/u/10704358?v=4",
+        "name": "kylegospo",
+        "description": "LatencyFlex"
+    },
+    {
+        "url": "https://github.com/Zanieon",
+        "icon": "https://avatars.githubusercontent.com/u/11906641?v=4",
+        "name": "Zanieon",
+        "description": "Navmeshes, Frontier Defense"
+    },
+    {
+        "url": "https://github.com/Jan200101/",
+        "icon": "https://avatars.githubusercontent.com/u/15076013?v=4",
+        "name": "Jan200101",
+        "description": "Linux support, Launcher development/code-cleanup"
+    },
+    {
+        "url": "https://github.com/EM4Volts",
+        "icon": "https://avatars.githubusercontent.com/u/87427011?v=4",
+        "name": "EM4V",
+        "description": "Modding Docs, Doublebarrel Shotgun"
+    }
+]

--- a/dist/data/core.json
+++ b/dist/data/core.json
@@ -1,0 +1,50 @@
+[
+    {
+        "url": "https://github.com/BobTheBob9",
+        "icon": "https://avatars.githubusercontent.com/u/32057864?v=4",
+        "name": "bobthebob",
+        "description": "Big Man, Founder"
+    },
+    {
+        "url": "https://github.com/emma-miler",
+        "icon": "https://avatars.githubusercontent.com/u/27428383?v=4",
+        "name": "emmam",
+        "description": "Plugins, Invites, DiscordRPC, Launcher, Moderator, Security"
+    },
+    {
+        "url": "https://github.com/RoyalBlue1",
+        "icon": "https://avatars.githubusercontent.com/u/11448698?v=4",
+        "name": "royalblue",
+        "description": "Squirrel, Frontier Defense, Tool Developer"
+    },
+    {
+        "url": "https://github.com/GeckoEidechse",
+        "icon": "https://avatars.githubusercontent.com/u/40122905?v=4",
+        "name": "gecko",
+        "description": "Release Management, Maintainer, Security, FlightCore"
+    },
+    {
+        "url": "https://github.com/pg9182",
+        "icon": "https://avatars.githubusercontent.com/u/96569817?v=4",
+        "name": "pg9182",
+        "description": "Atlas, Server Container, Stubs, Linux, Security"
+    },
+    {
+        "url": "https://github.com/wolf109909",
+        "icon": "https://avatars.githubusercontent.com/u/84360921?v=4",
+        "name": "wolf109909",
+        "description": "NorthstarCN"
+    },
+    {
+        "url": "https://github.com/p0358",
+        "icon": "https://avatars.githubusercontent.com/u/5182588?v=4",
+        "name": "p0358",
+        "description": "Source Genius, TFO, DLL Injector, Origin LSX"
+    },
+    {
+        "url": "https://github.com/ASpoonPlaysGames",
+        "icon": "https://avatars.githubusercontent.com/u/66967891?v=4",
+        "name": "spoon",
+        "description": "RPak/Starpak, Stats/Progression, Persistence, Advocate, Bug fixes"
+    }
+]

--- a/dist/data/past-contrib.json
+++ b/dist/data/past-contrib.json
@@ -1,0 +1,26 @@
+[
+    {
+        "url": "https://github.com/abarichello",
+        "icon": "https://avatars.githubusercontent.com/u/16687318?v=4",
+        "name": "barichello",
+        "description": "Code Formatting, Github-CI"
+    },
+    {
+        "url": "https://github.com/KittenPopo",
+        "icon": "https://avatars.githubusercontent.com/u/28826980?v=4",
+        "name": "kittenpopo",
+        "description": "Exploit fixes, Security"
+    },
+    {
+        "url": "https://github.com/geniiii",
+        "icon": "https://avatars.githubusercontent.com/u/24881499?v=4",
+        "name": "geni",
+        "description": "Early Fixes"
+    },
+    {
+        "url": "https://github.com/warmist",
+        "icon": "https://avatars.githubusercontent.com/u/917145?v=4",
+        "name": "warmist",
+        "description": "NavMeshes"
+    }
+]

--- a/dist/script/credits.js
+++ b/dist/script/credits.js
@@ -21,9 +21,9 @@ function addContributor(group, url, icon, name, description) {
  */
 function loadCredits() {
     // Load core contributors
-    fetch('/data/core.json') // Fetch the JSON file
-        .then(response => response.json()) // Parse the JSON data
-        .then(data => { // Add each member to least
+    fetch('/data/core.json')
+        .then(response => response.json())
+        .then(data => {
             data.forEach(item => {
                 addContributor("core", item.url, item.icon, item.name, item.description);
             });
@@ -31,9 +31,9 @@ function loadCredits() {
         .catch(error => console.error('Error fetching the JSON file:', error));
 
     // Load contributors
-    fetch('/data/contrib.json') // Fetch the JSON file
-        .then(response => response.json()) // Parse the JSON data
-        .then(data => { // Add each member to least
+    fetch('/data/contrib.json')
+        .then(response => response.json())
+        .then(data => {
             data.forEach(item => {
                 addContributor("contrib", item.url, item.icon, item.name, item.description);
             });
@@ -41,9 +41,9 @@ function loadCredits() {
         .catch(error => console.error('Error fetching the JSON file:', error));
 
     // Load past contributors
-    fetch('/data/past-contrib.json') // Fetch the JSON file
-        .then(response => response.json()) // Parse the JSON data
-        .then(data => { // Add each member to least
+    fetch('/data/past-contrib.json')
+        .then(response => response.json())
+        .then(data => {
             data.forEach(item => {
                 addContributor("past-contrib", item.url, item.icon, item.name, item.description);
             });

--- a/dist/script/credits.js
+++ b/dist/script/credits.js
@@ -39,11 +39,17 @@ function loadCredits() {
             });
         })
         .catch(error => console.error('Error fetching the JSON file:', error));
+
+    // Load past contributors
+    fetch('/data/past-contrib.json') // Fetch the JSON file
+        .then(response => response.json()) // Parse the JSON data
+        .then(data => { // Add each member to least
+            data.forEach(item => {
+                addContributor("past-contrib", item.url, item.icon, item.name, item.description);
+            });
+        })
+        .catch(error => console.error('Error fetching the JSON file:', error));
 }
 
 loadCredits();
 
-addContributor("past-contrib", "https://github.com/abarichello", "https://avatars.githubusercontent.com/u/16687318?v=4", "barichello", "Code Formatting, Github-CI")
-addContributor("past-contrib", "https://github.com/KittenPopo", "https://avatars.githubusercontent.com/u/28826980?v=4", "kittenpopo", "Exploit fixes, Security")
-addContributor("past-contrib", "https://github.com/geniiii", "https://avatars.githubusercontent.com/u/24881499?v=4", "geni", "Early Fixes")
-addContributor("past-contrib", "https://github.com/warmist", "https://avatars.githubusercontent.com/u/917145?v=4", "warmist", "NavMeshes")

--- a/dist/script/credits.js
+++ b/dist/script/credits.js
@@ -16,15 +16,22 @@ function addContributor(group, url, icon, name, description) {
     document.getElementById(group).insertAdjacentHTML("beforeend", x);
 }
 
-addContributor("core", "https://github.com/BobTheBob9", "https://avatars.githubusercontent.com/u/32057864?v=4", "bobthebob", "Big Man, Founder")
-addContributor("core", "https://github.com/emma-miler", "https://avatars.githubusercontent.com/u/27428383?v=4", "emmam", "Plugins, Invites, DiscordRPC, Launcher, Moderator, Security")
-addContributor("core", "https://github.com/RoyalBlue1", "https://avatars.githubusercontent.com/u/11448698?v=4", "royalblue", "Squirrel, Frontier Defense, Tool Developer")
-addContributor("core", "https://github.com/GeckoEidechse", "https://avatars.githubusercontent.com/u/40122905?v=4", "gecko", "Release Management, Maintainer, Security, FlightCore")
-addContributor("core", "https://github.com/pg9182", "https://avatars.githubusercontent.com/u/96569817?v=4", "pg9182", "Atlas, Server Container, Stubs, Linux, Security")
-addContributor("core", "https://github.com/wolf109909", "https://avatars.githubusercontent.com/u/84360921?v=4", "wolf109909", "NorthstarCN")
+/**
+ * Loads the members of various categories from JSON
+ */
+function loadCredits() {
+    // Load core contributors
+    fetch('/data/core.json') // Fetch the JSON file
+        .then(response => response.json()) // Parse the JSON data
+        .then(data => { // Add each member to least
+            data.forEach(item => {
+                addContributor("core", item.url, item.icon, item.name, item.description);
+            });
+        })
+        .catch(error => console.error('Error fetching the JSON file:', error));
+}
 
-addContributor("core", "https://github.com/p0358", "https://avatars.githubusercontent.com/u/5182588?v=4", "p0358", "Source Genius, TFO, DLL Injector, Origin LSX")
-addContributor("core", "https://github.com/ASpoonPlaysGames", "https://avatars.githubusercontent.com/u/66967891?v=4", "spoon", "RPak/Starpak, Stats/Progression, Persistence, Advocate, Bug fixes")
+loadCredits();
 
 addContributor("contrib", "https://github.com/BigSpice", "https://avatars.githubusercontent.com/u/23240514?v=4", "juicy", "VTOL, Skins")
 addContributor("contrib", "https://github.com/taskinoz", "https://avatars.githubusercontent.com/u/7439692?v=4", "taskinoz", "Moderator, NavMeshes")

--- a/dist/script/credits.js
+++ b/dist/script/credits.js
@@ -29,42 +29,19 @@ function loadCredits() {
             });
         })
         .catch(error => console.error('Error fetching the JSON file:', error));
+
+    // Load contributors
+    fetch('/data/contrib.json') // Fetch the JSON file
+        .then(response => response.json()) // Parse the JSON data
+        .then(data => { // Add each member to least
+            data.forEach(item => {
+                addContributor("contrib", item.url, item.icon, item.name, item.description);
+            });
+        })
+        .catch(error => console.error('Error fetching the JSON file:', error));
 }
 
 loadCredits();
-
-addContributor("contrib", "https://github.com/BigSpice", "https://avatars.githubusercontent.com/u/23240514?v=4", "juicy", "VTOL, Skins")
-addContributor("contrib", "https://github.com/taskinoz", "https://avatars.githubusercontent.com/u/7439692?v=4", "taskinoz", "Moderator, NavMeshes")
-addContributor("contrib", "https://github.com/laundmo", "https://avatars.githubusercontent.com/u/24855949?v=4", "laundmo", "Modding Docs, Chathooks")
-addContributor("contrib", "https://github.com/DBmaoha/", "https://avatars.githubusercontent.com/u/56738369?v=4", "VoyageDB", "Frontier War, Bounty Hunt, Squirrel bug fixes")
-addContributor("contrib", "https://github.com/barnabwhy", "https://avatars.githubusercontent.com/u/22575741?v=4", "barnaby", "Master Server, Website")
-
-addContributor("contrib", "https://github.com/Erlite", "https://avatars.githubusercontent.com/u/25248023?v=4", "erlite", "Spyglass, WebSquirrel, Security")
-addContributor("contrib", "https://github.com/Mauler125", "https://avatars.githubusercontent.com/u/48657826?v=4", "amos", "Source Genius, RCON, R5R, Security")
-addContributor("contrib", "https://github.com/cpdt", "https://avatars.githubusercontent.com/u/16081865?v=4", "snnag", "Chathooks, Server Browser, Exploit fixes, Security")
-addContributor("contrib", "https://github.com/F1F7Y", "https://avatars.githubusercontent.com/u/64418963?v=4", "f1f7y", "Server Browser, Attrition, Maps")
-addContributor("contrib", "https://github.com/snake-biscuits", "https://avatars.githubusercontent.com/u/36507175?v=4", "b1scuit", "Maps")
-
-
-addContributor("contrib", "https://github.com/Legonzaur", "https://avatars.githubusercontent.com/u/34353603?v=4", "legonzaur", "Discord Bot")
-addContributor("contrib", "https://github.com/catornot", "https://avatars.githubusercontent.com/u/41955154?v=4", "cat_or_not", "Co-Op Singleplayer")
-addContributor("contrib", "https://github.com/x3Karma", "https://avatars.githubusercontent.com/u/22678145?v=4", "x3karma", "Moderator, Modding, Frontier Defense")
-addContributor("contrib", "https://github.com/Alystrasz", "https://avatars.githubusercontent.com/u/11993538?v=4", "alystrasz", "Localisations, Launchers, Documentation")
-addContributor("contrib", "https://github.com/Dinorush", "https://avatars.githubusercontent.com/u/62536724?v=4", "dinorush", "Gamemodes")
-addContributor("contrib", "https://github.com/hummusbird", "https://avatars.githubusercontent.com/u/38541651?v=4", "birb", "Server Bot")
-addContributor("contrib", "https://github.com/H0L0theBard", "https://avatars.githubusercontent.com/u/97146561?v=4", "h0l0", "Moderator, Server Bot, Co-Op Singleplayer")
-addContributor("contrib", "https://github.com/uniboi", "https://avatars.githubusercontent.com/u/64006268?v=4", "uniboi", "Modding Docs")
-addContributor("contrib", "https://github.com/EladNLG", "https://avatars.githubusercontent.com/u/44613424?v=4", "eladnlg", "UI, Modding, Roguelike")
-
-addContributor("contrib", "https://github.com/r-ex", "https://avatars.githubusercontent.com/u/67599507?v=4", "rexx", "Custom Models, </br> Legion, RePak")
-addContributor("contrib", "https://github.com/headassbtw", "https://avatars.githubusercontent.com/u/16214950?v=4", "headass", "Custom Models")
-addContributor("contrib", "https://github.com/Masterliberty", "https://avatars.githubusercontent.com/u/94194459?v=4", "masterliberty", "Custom Models")
-
-addContributor("contrib", "https://github.com/KyleGospo", "https://avatars.githubusercontent.com/u/10704358?v=4", "kylegospo", "LatencyFlex")
-
-addContributor("contrib", "https://github.com/Zanieon", "https://avatars.githubusercontent.com/u/11906641?v=4", "Zanieon", "Navmeshes, Frontier Defense")
-addContributor("contrib", "https://github.com/Jan200101/", "https://avatars.githubusercontent.com/u/15076013?v=4", "Jan200101", "Linux support, Launcher development/code-cleanup")
-addContributor("contrib", "https://github.com/EM4Volts", "https://avatars.githubusercontent.com/u/87427011?v=4", "EM4V", "Modding Docs, Doublebarrel Shotgun")
 
 addContributor("past-contrib", "https://github.com/abarichello", "https://avatars.githubusercontent.com/u/16687318?v=4", "barichello", "Code Formatting, Github-CI")
 addContributor("past-contrib", "https://github.com/KittenPopo", "https://avatars.githubusercontent.com/u/28826980?v=4", "kittenpopo", "Exploit fixes, Security")


### PR DESCRIPTION
This PR loads the credits for various categories (`core`, `contrib`, `past-contrib`) from JSON files instead of hardcoding the values in JS.

The reason being that I'm planning to add another category called `community`.
With the move to JSON I can add a [scheduled GitHub Actions feature](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) that pulls all the contributors from all repositories and then commits the resulting JSON file.
This means we can get a regularly updated list of all contributors shown on the website :eyes:


Rendered result:
(They should look the same)

Before this PR  |  This PR:
:-------------------------:|:-------------------------:
![image](https://github.com/R2Northstar/NorthstarTF/assets/40122905/c107b34f-1409-4e8d-b59e-52019aa4e70f)  |  ![image](https://github.com/R2Northstar/NorthstarTF/assets/40122905/3fc70802-cf5a-46cc-9536-aa18a1013b38)
