### PR TITLE
Remove viper from the main page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -102,20 +102,6 @@
             </div>
             <div class="launcher">
                 <div class="header"> 
-                    <img src="/assets/viper.png">
-                    <div class="name header">viper</div>
-                </div>
-                <div class="blurb">
-                    Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.
-                    </p>Supports Windows and Linux.
-                </div>
-                <div class="buttons">
-                    <a ondragstart="return false;" href="https://0negal.github.io/viper" target="_blank" class="button"><img src="/assets/manual.png" /><span>Download</span></a>
-                    <a ondragstart="return false;" href="https://github.com/0neGal/viper" target="_blank" class="button"><img src="/assets/github.png" /><span>Github</span></a>
-                </div>
-            </div>
-            <div class="launcher">
-                <div class="header"> 
                     <img src="/assets/manual.png">
                     <div class="name header">manual</div>
                 </div>


### PR DESCRIPTION
Removes the couple lines in the html that reference viper. 
dont care if this is "unfair", viper is the sole cause of 99.6% of all issues that happen and are related to launchers, flightcore has linux support if thats another reason.

thank me later.

didnt test this, the file looks fine i think. 