### PR TITLE
Create installers subpage

### DIFF
--- a/dist/data/installers.json
+++ b/dist/data/installers.json
@@ -3,6 +3,7 @@
         "icon": "/assets/flightcore.png",
         "name": "FlightCore",
         "description": "Fast and easy to use Northstar installer, updater, launcher, and mod-manager. Features built-in mod browser and allows for easy installation of pre-release versions of Northstar.",
+        "featured": true,
         "tags": [
             "Windows",
             "Linux"
@@ -22,6 +23,7 @@
         "icon": "/assets/vtol.png",
         "name": "VTOL",
         "description": "Easy to use and extensive Northstar installer and mod-manager. Supports installing from Thunderstore as well as from outside sources like GitHub/GitLab. Supports installing custom weapon/pilot skins and managing dedicated servers.",
+        "featured": true,
         "tags": [
             "Windows"
         ],
@@ -40,6 +42,7 @@
         "icon": "/assets/viper.png",
         "name": "Viper",
         "description": "Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.",
+        "featured": false,
         "tags": [
             "Windows"
         ],
@@ -58,6 +61,7 @@
         "icon": "/assets/manual.svg",
         "name": "Manual",
         "description": "You can install Northstar manually if you want to. Note that Northstar does not automatically update when installed this way.",
+        "featured": true,
         "tags": [
             "Windows",
             "Linux"

--- a/dist/index.html
+++ b/dist/index.html
@@ -41,6 +41,7 @@
         <div id="toplinks" class="toplinks">
             <a class="top-link" href="/">home</a>
             <div class="spacer"></div>
+            <a class="top-link" href="/installers">installers</a>
             <a class="top-link" href="/servers">servers</a>
             <a class="top-link" href="/credits">contributors</a>
             <a class="top-link" href="/thunderstore">mods</a>
@@ -96,7 +97,7 @@
         <!-- Mastodon verification -->
         <a rel="me" href="https://fosstodon.org/@R2Northstar" style="display: none; visibility: hidden;">Mastodon</a>
     </div>
-    <script src="/script/installers.js" onload="loadsInstallers()"></script>
+    <script src="/script/installers.js" onload="loadsInstallers(true)"></script>
     <script src="/script/index.js"></script>
 </body>
 </html>

--- a/dist/installers/index.html
+++ b/dist/installers/index.html
@@ -7,7 +7,7 @@
     <title>Northstar</title>
     <link rel="canonical" href="https://northstar.tf/credits/">
 
-    <link rel="stylesheet" href="/style/credits.css">
+    <link rel="stylesheet" href="/style/installers.css">
     <link rel="stylesheet" href="/style/header.css">
     <link rel="stylesheet" href="/style/footer.css">
     <link rel="stylesheet" href="/style/common.css">
@@ -49,34 +49,22 @@
         </div>
     </div>
     <div class="pane">
-        <div class="section">Core</div>
-        <div class="contributors" id="core"/>
+        <div class="section">All Installers</div>
+        <div class="installoptions" id="installers"/>
     </div>
     <div class="pane">
-        <div class="section">Contributors</div>
-        <div class="contributors small" id="contrib"/>
-    </div>
-    <div class="pane">
-        <div class="section">Past contributors</div>
-        <p class="blurb">We are ever greatful for past contributions by these developers and wish them all their best on their journey beyond Northstar</p>
-        <div class="contributors small" id="past-contrib"/>
-    </div>
-    <div class="pane">
-        <div class="attribution">
-            Missing anyone on this list? Outdated entries? Feel free to <a href="https://github.com/R2Northstar/NorthstarTF/">open a pull request</a> to make changes to this site.
-            <br />
-            <br />
-            This site or product includes IP2Location LITE data available from <a href="https://lite.ip2location.com">https://lite.ip2location.com</a>.
+        <div class="missing">
+            Is anything missing from this list? Outdated entries? Feel free to <a href="https://github.com/R2Northstar/NorthstarTF/">open a pull request</a> to make changes to this site.
         </div>
     </div>
     <br style="font-size: 32px;">
     <div class="footer pane">
         <a href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-        <a href="/github"><img src="/assets/github.svg" alt="Modding Documentation"/>GitHub</a>
+        <a href="/github"><img src="/assets/github.png" alt="Modding Documentation"/>GitHub</a>
         <a href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
         <a href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
     </div>
-    <script src="/script/credits.js" type="module"></script>
+    <script src="/script/installers.js" onload="loadsInstallers(false)"></script>
     <script src="/script/index.js"></script>
 </body>
 </html>

--- a/dist/script/installers.js
+++ b/dist/script/installers.js
@@ -8,7 +8,7 @@ var button_template = `
 <a
     ondragstart="return false;"
     href="URL"
-    target="_blank"
+    target="TARGET"
     class="button"
 >
     <img src="ICON" />
@@ -34,7 +34,7 @@ var template = `
 </div>
 `
 
-function addInstaller(group, icon, name, description, tags, buttons) {
+function addInstaller(group, icon, name, description, tags, buttons, target) {
     var tagsstr = "";
     var buttonsstr = "";
 
@@ -46,7 +46,8 @@ function addInstaller(group, icon, name, description, tags, buttons) {
         buttonsstr += button_template
             .replace("NAME", name)
             .replace("URL", buttons[name].url)
-            .replace("ICON", buttons[name].icon);
+            .replace("ICON", buttons[name].icon)
+            .replace("TARGET", target);
     }
 
     var x = template.replace("ICONNAME", icon)
@@ -58,13 +59,16 @@ function addInstaller(group, icon, name, description, tags, buttons) {
     document.getElementById(group).insertAdjacentHTML("beforeend", x);
 }
 
-function loadsInstallers() {
+function loadsInstallers(home) {
     fetch('/data/installers.json')
         .then(response => response.json())
         .then(data => {
             data.forEach(item => {
-                addInstaller("installers", item.icon, item.name, item.description, item.tags, item.buttons);
+                if (home && !item.featured) return;
+                addInstaller("installers", item.icon, item.name, item.description, item.tags, item.buttons, "_blank");
             });
+            if (home)
+                addInstaller("installers", "/assets/icon_wiki.svg", "Other Installers", "See a full list of Northstar Installers", [], {"Other Installers": {"icon": "/assets/icon_wiki.svg", "url": "/installers"}}, "");
         })
         .catch(error => console.error('Error fetching the JSON file:', error));
 }

--- a/dist/style/header.css
+++ b/dist/style/header.css
@@ -68,7 +68,7 @@ input[type="checkbox"][id^="cb"] {
     background-color: rgba(0,0,0,0.5);
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1290px) {
     .menu-selector {
         display: inline;
     }

--- a/dist/style/installers.css
+++ b/dist/style/installers.css
@@ -1,0 +1,98 @@
+
+.installoptions { 
+    display: flex;
+    justify-content: center;
+    width: 90%;
+    margin-left: 5%;
+    flex-wrap: wrap;
+    gap: 4em;
+}
+
+.launcher {
+    width: 20%;
+    display: flex;
+    flex-direction: column;
+}
+
+.launcher > * > img {
+    height: 4em;
+    width: 4em;
+    max-width: 100%;
+}
+
+.header {
+    display: flex;
+    padding-top: 0.5em;
+    padding-bottom: 1em;
+}
+
+.name {
+    font-family: Titanfall;
+    font-size: 1.8em;
+    align-self: center;
+    margin-left: -0.1em;
+    margin-top: 0.05em;
+}
+
+.blurb {
+    padding-bottom: 1em;
+}
+
+@media screen and (max-width: 1280px) {
+    .launcher > .header {
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        margin-right: 3em;
+    }
+    .launcher > .header > .name {
+        margin-top: 0.5em;
+    }
+    .launcher > .buttons {
+        align-self: flex-center;
+    }
+    .installoptions { 
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+        width: 90%;
+        margin-left: 5%;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        align-items: stretch;
+    }
+    .launcher {
+        flex: 1;
+        min-width: 15em;
+        max-width: 50em;
+        margin-top: 1em;
+        margin-bottom: 1em;
+    }
+}
+
+.buttons {
+    display: flex;
+    margin-top: 10px;
+}
+
+.launcher > * > .button {
+    width: 100%;
+}
+
+img {
+    vertical-align: middle;
+    width: 16px;
+    height: 16px;
+    margin-right: 12px;
+    pointer-events: none;
+    margin-top: -2px;
+}
+
+
+.missing {
+    opacity: 0.5;
+    margin-top: 16px;
+    font-size: .875em;
+    text-align: center;
+}


### PR DESCRIPTION
Creates a new installer subpage with all known installers (even those that are less mature or WIP).

The logic is kept similar to the credits subpage where everything is loaded from a json file.

The installation section on the main page also now uses the same logic to allow the use of tags.

I've also removed the "module" type from the credit scripts because we don't depend on anything that doesn't exist when the script is ran.

Menu bar
![image](https://github.com/R2Northstar/NorthstarTF/assets/15076013/177b5faf-008e-46f9-8b13-d13f8b496ec0)

Main page (having js on the main page could be considered bloat however we also embed a big ass mp4 in the background so ...)
![image](https://github.com/R2Northstar/NorthstarTF/assets/15076013/5a7fc4c0-3124-47a6-bf9d-cfa3005605cf)

Installers page (the footer is high which is also how the credits page is without enough elements)
![image](https://github.com/R2Northstar/NorthstarTF/assets/15076013/e7bfe66f-a4b9-4653-89cf-74b9882ede59)

related to #48 
@GeckoEidechse 
