### PR TITLE
Lazy load GitHub profile pictures

### DIFF
--- a/dist/script/credits.js
+++ b/dist/script/credits.js
@@ -1,6 +1,6 @@
 var template = `
 <div class="contributor" >
-    <img src="ICONNAME" onclick="window.open('URL')">
+    <img src="ICONNAME" onclick="window.open('URL')" loading="lazy">
     <a class="name header">USERNAME</a>
     <div class="blurb">
         DESCRIPTION


### PR DESCRIPTION
So they only get loaded when scrolled to.

Spliced from #52