### PR TITLE
Add clarification subtext to `Installers`

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -74,7 +74,7 @@
     </div>
     <div class="pane" id="main">
         <div class="section">Installation</div>
-        <p style="text-align: center" class="launchersubtext">These all install the same Northstar!</p>
+        <p style="text-align: center" class="launchersubtext">These are all ways to install the same Northstar!</p>
         <div class="installoptions" id="installers">
         </div>
     </div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -74,6 +74,7 @@
     </div>
     <div class="pane" id="main">
         <div class="section">Installation</div>
+        <p style="text-align: center" class="launchersubtext">These all install the same Northstar!</p>
         <div class="installoptions" id="installers">
         </div>
     </div>


### PR DESCRIPTION
I think this is a much better way to implement what I wanted to all the way back with #26.

Many users are often confused at the multiple options for installing Northstar, so this should hopefully clarify, for at least one or two people, that they all do (relatively) the same thing.

~~Here's an actual preview of what the change looks like:~~ (see comment below, had the wrong tab open so this was outdated)

The text is a little small, but I don't think it needs to be much bigger, unless that's preferred