### PR TITLE
Fix alt text for GitHub icon

### DIFF
--- a/dist/credits/index.html
+++ b/dist/credits/index.html
@@ -71,7 +71,7 @@
     <br style="font-size: 32px;">
     <div class="footer pane">
         <a href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-        <a href="/github"><img src="/assets/github.svg" alt="Modding Documentation"/>GitHub</a>
+        <a href="/github"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
         <a href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
         <a href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
     </div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -62,7 +62,7 @@
             <div class="centerbuttons">
                 <a ondragstart="return false;" href="/discord" target="_blank" class="button big"><img src="/assets/icon_discord.svg" alt="Discord Server"/><span>Discord</span></a>
                 <a href="/wiki" class="button big"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-                <a href="/github" class="button big"><img src="/assets/github.svg" alt="Modding Documentation"/>GitHub</a>
+                <a href="/github" class="button big"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
                 <a href="/servers" class="button big"><img src="/assets/globe.svg" alt="Modding Documentation"/>Server Browser</a>
             </div>
             <div class="scrolldown" onclick="scrollToMain();">
@@ -90,7 +90,7 @@
     <br style="font-size: 5em;">
     <div class="footer pane">
         <a ondragstart="return false;" href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-        <a ondragstart="return false;" href="/github"><img src="/assets/github.svg" alt="Modding Documentation"/>GitHub</a>
+        <a ondragstart="return false;" href="/github"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
         <a ondragstart="return false;" href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
         <a ondragstart="return false;" href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
         <!-- Mastodon verification -->

--- a/dist/servers/index.html
+++ b/dist/servers/index.html
@@ -108,7 +108,7 @@
 <footer>
     <div class="footer">
         <a href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-        <a href="/github"><img src="/assets/github.svg" alt="Modding Documentation"/>GitHub</a>
+        <a href="/github"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
         <a href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
         <a href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
     </div>


### PR DESCRIPTION
When the site was first made, the alt text for the GitHub icon was incorrectly set to "Modding Documentation".
Since then it continued to get copy-pasted to other subpages without anyone ever noticing.