### PR TITLE
Add installers subpage

### DIFF
--- a/dist/data/installers.json
+++ b/dist/data/installers.json
@@ -3,6 +3,7 @@
         "icon": "/assets/flightcore.png",
         "name": "FlightCore",
         "description": "Fast and easy to use Northstar installer, updater, launcher, and mod-manager. Features built-in mod browser and allows for easy installation of pre-release versions of Northstar.",
+        "featured": true,
         "tags": [
             "Windows",
             "Linux"
@@ -22,6 +23,7 @@
         "icon": "/assets/vtol.png",
         "name": "VTOL",
         "description": "Easy to use and extensive Northstar installer and mod-manager. Supports installing from Thunderstore as well as from outside sources like GitHub/GitLab. Supports installing custom weapon/pilot skins and managing dedicated servers.",
+        "featured": true,
         "tags": [
             "Windows"
         ],
@@ -40,6 +42,7 @@
         "icon": "/assets/viper.png",
         "name": "Viper",
         "description": "Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.",
+        "featured": true,
         "tags": [
             "Windows"
         ],
@@ -58,6 +61,7 @@
         "icon": "/assets/manual.svg",
         "name": "Manual",
         "description": "You can install Northstar manually if you want to. Note that Northstar does not automatically update when installed this way.",
+        "featured": true,
         "tags": [
             "Windows",
             "Linux"

--- a/dist/index.html
+++ b/dist/index.html
@@ -41,6 +41,7 @@
         <div id="toplinks" class="toplinks">
             <a class="top-link" href="/">home</a>
             <div class="spacer"></div>
+            <a class="top-link" href="/installers">installers</a>
             <a class="top-link" href="/servers">servers</a>
             <a class="top-link" href="/credits">contributors</a>
             <a class="top-link" href="/thunderstore">mods</a>
@@ -96,7 +97,7 @@
         <!-- Mastodon verification -->
         <a rel="me" href="https://fosstodon.org/@R2Northstar" style="display: none; visibility: hidden;">Mastodon</a>
     </div>
-    <script src="/script/installers.js" onload="loadsInstallers()"></script>
+    <script src="/script/installers.js" onload="loadsInstallers(true)"></script>
     <script src="/script/index.js"></script>
 </body>
 </html>

--- a/dist/installers/index.html
+++ b/dist/installers/index.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Northstar</title>
-    <link rel="canonical" href="https://northstar.tf/credits/">
+    <link rel="canonical" href="https://northstar.tf/installers/">
 
-    <link rel="stylesheet" href="/style/credits.css">
+    <link rel="stylesheet" href="/style/installers.css">
     <link rel="stylesheet" href="/style/header.css">
     <link rel="stylesheet" href="/style/footer.css">
     <link rel="stylesheet" href="/style/common.css">
@@ -15,21 +15,24 @@
 
     <!-- Primary Meta Tags -->
     <meta name="title" content="Northstar">
-    <meta name="description" content="The contributors to the Northstar project.">
+    <meta name="description" content="Installers for Northstar.">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://northstar.tf/">
     <meta property="og:title" content="Northstar">
-    <meta property="og:description" content="The contributors to the Northstar project.">
+    <meta property="og:description" content="Installers for Northstar.">
     <meta property="og:image" content="/assets/NorthstarPromoPosterOG.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://northstar.tf/">
     <meta property="twitter:title" content="Northstar">
-    <meta property="twitter:description" content="The contributors to the Northstar project.">
+    <meta property="twitter:description" content="Installers for Northstar">
     <meta property="twitter:image" content="/assets/NorthstarPromoPosterOG.jpg">
+
+    <link rel="preload" href="/assets/titanfall_new.ttf" as="font" type="font/ttf" crossorigin>
+    <link rel="preload" href="/data/installers.json" as="fetch" crossorigin>
 </head>
 <body>
     <div id="top">
@@ -49,34 +52,23 @@
         </div>
     </div>
     <div class="pane">
-        <div class="section">Core</div>
-        <div class="contributors" id="core"/>
+        <div class="section">All Installers</div>
+        <div class="installoptions" id="installers"/>
     </div>
     <div class="pane">
-        <div class="section">Contributors</div>
-        <div class="contributors small" id="contrib"/>
-    </div>
-    <div class="pane">
-        <div class="section">Past contributors</div>
-        <p class="blurb">We are ever greatful for past contributions by these developers and wish them all their best on their journey beyond Northstar</p>
-        <div class="contributors small" id="past-contrib"/>
-    </div>
-    <div class="pane">
-        <div class="attribution">
-            Missing anyone on this list? Outdated entries? Feel free to <a href="https://github.com/R2Northstar/NorthstarTF/">open a pull request</a> to make changes to this site.
-            <br />
-            <br />
-            This site or product includes IP2Location LITE data available from <a href="https://lite.ip2location.com">https://lite.ip2location.com</a>.
+        <div class="missing">
+            Is anything missing from this list? Outdated entries? Feel free to <a href="https://github.com/R2Northstar/NorthstarTF/">open a pull request</a> to make changes to this site.
         </div>
     </div>
+
     <br style="font-size: 32px;">
     <div class="footer pane">
-        <a href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
-        <a href="/github"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
-        <a href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
-        <a href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
+        <a ondragstart="return false;" href="/wiki"><img src="/assets/icon_wiki.svg" alt="Northstar Wiki"/>Wiki</a>
+        <a ondragstart="return false;" href="/github"><img src="/assets/github.svg" alt="GitHub"/>GitHub</a>
+        <a ondragstart="return false;" href="https://r2northstar.readthedocs.io/"><img src="/assets/icon_moddingdocs.svg" alt="Modding Documentation"/>Modding Docs</a>
+        <a ondragstart="return false;" href="/discord"><img src="/assets/icon_discord.svg" alt="Discord Server"/>Discord</a>
     </div>
-    <script src="/script/credits.js" type="module"></script>
+    <script src="/script/installers.js" onload="loadsInstallers(false)"></script>
     <script src="/script/index.js"></script>
 </body>
 </html>

--- a/dist/script/installers.js
+++ b/dist/script/installers.js
@@ -8,7 +8,7 @@ var button_template = `
 <a
     ondragstart="return false;"
     href="URL"
-    target="_blank"
+    target="TARGET"
     class="button"
 >
     <img src="ICON" />
@@ -34,7 +34,7 @@ var template = `
 </div>
 `
 
-function addInstaller(group, icon, name, description, tags, buttons) {
+function addInstaller(group, icon, name, description, tags, buttons, target) {
     var tagsstr = "";
     var buttonsstr = "";
 
@@ -46,7 +46,8 @@ function addInstaller(group, icon, name, description, tags, buttons) {
         buttonsstr += button_template
             .replace("NAME", name)
             .replace("URL", buttons[name].url)
-            .replace("ICON", buttons[name].icon);
+            .replace("ICON", buttons[name].icon)
+            .replace("TARGET", target);
     }
 
     var x = template.replace("ICONNAME", icon)
@@ -58,13 +59,24 @@ function addInstaller(group, icon, name, description, tags, buttons) {
     document.getElementById(group).insertAdjacentHTML("beforeend", x);
 }
 
-function loadsInstallers() {
+function loadsInstallers(home) {
     fetch('/data/installers.json')
         .then(response => response.json())
         .then(data => {
             data.forEach(item => {
-                addInstaller("installers", item.icon, item.name, item.description, item.tags, item.buttons);
+                if (home && !item.featured) return;
+                addInstaller("installers", item.icon, item.name, item.description, item.tags, item.buttons, "_blank");
             });
+            if (home)
+                addInstaller(
+                    "installers",
+                    "/assets/icon_wiki.svg",
+                    "Other Installers",
+                    "See a full list of Northstar Installers",
+                    [],
+                    {"Other Installers": {"icon": "/assets/icon_wiki.svg", "url": "/installers"}},
+                    ""
+            );
         })
         .catch(error => console.error('Error fetching the JSON file:', error));
 }

--- a/dist/style/header.css
+++ b/dist/style/header.css
@@ -68,7 +68,7 @@ input[type="checkbox"][id^="cb"] {
     background-color: rgba(0,0,0,0.5);
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1290px) {
     .menu-selector {
         display: inline;
     }

--- a/dist/style/installers.css
+++ b/dist/style/installers.css
@@ -1,0 +1,106 @@
+
+.installoptions {
+    display: flex;
+    justify-content: center;
+    width: 90%;
+    margin-left: 5%;
+    flex-wrap: wrap;
+    gap: 4em;
+}
+
+.launcher {
+    width: 20%;
+    display: flex;
+    flex-direction: column;
+}
+
+.launcher > * > img {
+    height: 4em;
+    width: 4em;
+    max-width: 100%;
+}
+
+.header {
+    display: flex;
+    padding-top: 0.5em;
+    padding-bottom: 1em;
+}
+
+.name {
+    font-family: Titanfall;
+    font-size: 1.8em;
+    align-self: center;
+    margin-left: -0.1em;
+    margin-top: 0.05em;
+}
+
+.blurb {
+    padding-bottom: 1em;
+}
+
+@media screen and (max-width: 1280px) {
+    .launcher > .header {
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        margin-right: 3em;
+    }
+    .launcher > .header > .name {
+        margin-top: 0.5em;
+    }
+    .launcher > .buttons {
+        align-self: flex-center;
+    }
+    .installoptions {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 2em;
+        width: 90%;
+        margin-left: 5%;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        align-items: stretch;
+    }
+    .launcher {
+        flex: 1;
+        min-width: 18em;
+        max-width: 36em;
+        margin-top: 1em;
+        margin-bottom: 1em;
+    }
+}
+
+.launcher > .buttons {
+    margin-top: 12px;
+    gap: 12px;
+}
+.launcher > .buttons > .button {
+    margin: 0px;
+}
+
+.buttons {
+    display: flex;
+    margin-top: auto;
+}
+
+.launcher > * > .button {
+    width: 100%;
+}
+
+img {
+    vertical-align: middle;
+    width: 16px;
+    height: 16px;
+    margin-right: 12px;
+    pointer-events: none;
+    margin-top: -2px;
+}
+
+
+.missing {
+    opacity: 0.5;
+    margin-top: 16px;
+    font-size: .875em;
+    text-align: center;
+}


### PR DESCRIPTION
Add a subpage listing all installers. This can in the future be extended to showcase more community made creations.

This is a continuation of #50 with some additional things fixed that I missed when additionally reviewing #50, updated with recent changes in main introduced by #52 and related PRs as well as no changes to which installers are considered featured for now.

As the majority of logic comes from #50 I made sure to co-author accordingly for appropriate contribution credit.