### PR TITLE
Re-add Linux tag for Viper

### DIFF
--- a/dist/data/installers.json
+++ b/dist/data/installers.json
@@ -44,7 +44,8 @@
         "description": "Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.",
         "featured": true,
         "tags": [
-            "Windows"
+            "Windows",
+            "Linux"
         ],
         "buttons": {
             "Download": {


### PR DESCRIPTION
Given that Viper now supports launching on Linux since [`1.12.0`](https://github.com/0neGal/viper/releases/tag/v1.12.0) release I think it's appropriate to re-instate the tag showing Linux support.