### PR TITLE
Load correct CSS for installers page

### DIFF
--- a/dist/installers/index.html
+++ b/dist/installers/index.html
@@ -7,7 +7,7 @@
     <title>Northstar</title>
     <link rel="canonical" href="https://northstar.tf/installers/">
 
-    <link rel="stylesheet" href="/style/index.css">
+    <link rel="stylesheet" href="/style/installers.css">
     <link rel="stylesheet" href="/style/header.css">
     <link rel="stylesheet" href="/style/footer.css">
     <link rel="stylesheet" href="/style/common.css">


### PR DESCRIPTION
Installers subpage has its own CSS file instead of the main one