### PR TITLE
Fix copy pasted leftovers on roadmap page

### DIFF
--- a/dist/roadmap/index.html
+++ b/dist/roadmap/index.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Northstar</title>
-    <link rel="canonical" href="https://northstar.tf/installers/">
+    <link rel="canonical" href="https://northstar.tf/roadmap/">
 
-    <link rel="stylesheet" href="/style/installers.css">
+    <link rel="stylesheet" href="/style/index.css">
     <link rel="stylesheet" href="/style/header.css">
     <link rel="stylesheet" href="/style/footer.css">
     <link rel="stylesheet" href="/style/common.css">
@@ -32,7 +32,6 @@
     <meta property="twitter:image" content="/assets/NorthstarPromoPosterOG.jpg">
 
     <link rel="preload" href="/assets/titanfall_new.ttf" as="font" type="font/ttf" crossorigin>
-    <link rel="preload" href="/data/installers.json" as="fetch" crossorigin>
 </head>
 <body>
     <div id="top">


### PR DESCRIPTION
There were a few leftover copy/pasted changes in #68 when it was merged.

This PR removes those.