### PR TITLE
Remove manual line break in rexx' description

### DIFF
--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -210,7 +210,7 @@ export const contributors: Contributor[] = [
         url: "https://github.com/r-ex",
         icon: "https://avatars.githubusercontent.com/u/67599507?v=4&s=128",
         name: "rexx",
-        description: "Custom Models, </br> Legion, RePak",
+        description: "Custom Models, Legion, RePak",
         type: ContributorType.CONTRIBUTOR,
     },
     {


### PR DESCRIPTION
Remove manual line break in rexx' description as it gets escaped with astro rewrite and is not necessary with proper spacing anyway

Before:

![image](https://github.com/user-attachments/assets/927a8155-e424-45cf-868e-6c6327fff822)

After:

![image](https://github.com/user-attachments/assets/119f1674-b1b1-4272-9c07-53c0553ae594)
