### PR TITLE
Move Viper and VTOL to collapsed section

### DIFF
--- a/src/data/installers.ts
+++ b/src/data/installers.ts
@@ -40,7 +40,7 @@ export const installers: Installer[] = [
         name: "VTOL",
         description:
             "Easy to use and extensive Northstar installer and mod-manager. Supports installing from Thunderstore as well as from outside sources like GitHub/GitLab. Supports installing custom weapon/pilot skins and managing dedicated servers.",
-        featured: true,
+        featured: false,
         tags: ["Windows"],
         buttons: [
             {
@@ -60,7 +60,7 @@ export const installers: Installer[] = [
         name: "Viper",
         description:
             "Simple and easy to use Northstar installer and auto-updater. Allows launching both Northstar and vanilla Titanfall 2. Features mod-manager and built-in mod browser for Thunderstore.",
-        featured: true,
+        featured: false,
         tags: ["Windows", "Linux"],
         buttons: [
             {


### PR DESCRIPTION
This IMO might be a controversial change given that I wrote FlightCore but there has a been a common sentiment over the last few months that out of FlightCore, VTOL, and Viper, FlightCore is the installer/mod-manager that causes the least issues with end-users.

It's not without reason that #48 exists. Further showing 4 different installation options confuses end-usersbased on feedback on Discord and it makes sense to highlight a mod-manager that is developed by someone closely associated with Northstar development.

At the same time I'm well aware of the improvements @0neGal made to Viper in the last few weeks and that VTOL also still sees development whenever @BigSpice is able to work on it.

So I struggle whether to merge this change or not and would highly appreciate any feedback on this <3

Rendered:

https://github.com/user-attachments/assets/47632442-dfdf-48a6-ba7f-1eb5c47ffc6b


Supersedes #48 
Sorta supersedes #64 
