### PR TITLE
Ignore GitHub Actions bot for community contributor list

### DIFF
--- a/scripts/scrape-for-contributors.py
+++ b/scripts/scrape-for-contributors.py
@@ -17,6 +17,7 @@ excluded_repos = [
 
 # List of users to exclude
 excluded_users = [
+    "github-actions[bot]",  # bot
     "dependabot[bot]",  # bot
     "harmony-weblate",  # bot
     "weblate",  # bot


### PR DESCRIPTION
Otherwise it gets added to the list as well as it tried via 5dfe7f16ac54a0b11651ae65fa0ba23d66bdf144