### PR TITLE
Add option to pass GitHub token via CLI arg

### DIFF
--- a/.github/workflows/periodic-scrape.yaml
+++ b/.github/workflows/periodic-scrape.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Run Python script for scraping
       run: |
         cd scripts
-        python scrape-for-contributors.py
+        python scrape-for-contributors.py ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check for changes
       id: git_diff

--- a/scripts/scrape-for-contributors.py
+++ b/scripts/scrape-for-contributors.py
@@ -1,10 +1,15 @@
 import re
 import requests
 from typing import List, Optional
+import sys
 
 github_token = (
-    None  # supply a github token to avoid ratelimit, or don't, it's up to you
+    None
 )
+
+# supply a github token in an arg avoid ratelimit, or don't, it's up to you
+if len(sys.argv) > 1:
+    github_token = sys.argv[1]
 
 contributor_list_file = "../src/data/contributors.ts"
 


### PR DESCRIPTION
Add option to pass GitHub token via CLI arg and make use of it in CI

Taken from #98 