### PR TITLE
Mention docs in Gecko's description

### DIFF
--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -40,7 +40,7 @@ export const contributors: Contributor[] = [
         url: "https://github.com/GeckoEidechse",
         icon: "https://avatars.githubusercontent.com/u/40122905?v=4&s=128",
         name: "gecko",
-        description: "Release Management, Maintainer, Security, FlightCore",
+        description: "Release Management, Maintainer, Security, FlightCore, Docs",
         type: ContributorType.CORE,
     },
     {


### PR DESCRIPTION
Add "Docs" as one of the areas in Gecko's description on credits page.