### PR TITLE
Add id attribute for direct linking to section

### DIFF
--- a/src/pages/credits.astro
+++ b/src/pages/credits.astro
@@ -30,7 +30,7 @@ import Layout from "../layouts/Layout.astro";
     </div>
 
     <!-- TODO have a pane for each and just pass the desired stats (weekly/monthly/all) to the component -->
-    <div class="pane">
+    <div class="pane" id="reviewer-scoreboard">
         <div class="section">Reviewer Scoreboard</div>
         <p class="blurb">Stats for number of reviews performed over certain time durations</p>
         <Reviewers />


### PR DESCRIPTION
Adds an id attribute to the container to be able to directly link to the section via `/credits/#reviewer-scoreboard`