### PR TITLE
Fixed full width "Other installers" button

### DIFF
--- a/src/components/Installers.astro
+++ b/src/components/Installers.astro
@@ -54,13 +54,17 @@ import { installers } from "../data/installers.ts";
         }
     }
 
+	details {
+		display: flex;
+	}
+
     summary {
-        margin: 2em 0 0 0;
-        width: 100%;
+        margin: 2em auto 0 auto;
+		width: min-content;
         user-select: none;
     }
     details[open] > summary {
-        margin: 2em 0;
+        margin: 2em auto;
     }
 
     summary::after {


### PR DESCRIPTION
I have no idea if this is intentional, just happened to go on the site to do something completely unrelated, and it didn't seem intentional?

<details open>
    <summary>Before</summary>
    <img src="https://github.com/user-attachments/assets/242aff20-d9fd-43b4-9d51-48e96d8a15a0">
</details

<details open>
    <summary>After</summary>
    <img src="https://github.com/user-attachments/assets/12461c7d-3b6d-4b10-b9a7-2d827fabeba7">
</details